### PR TITLE
Use array_replace_recursive for context values

### DIFF
--- a/lib/Horde/ManageSieve.php
+++ b/lib/Horde/ManageSieve.php
@@ -273,7 +273,7 @@ class ManageSieve
             $this->_params['port'] = $port;
         }
         if (isset($context)) {
-            $this->_params['context'] = array_merge_recursive(
+            $this->_params['context'] = array_replace_recursive(
                 $this->_params['context'],
                 $context
             );


### PR DESCRIPTION
A context array, user and password passed to constructor is leading to duplicated values for the context options.

```
$params = [
    'host' => 'localhost',
    'port' => 4190,
    'user' => 'user@domain.tld',
    'password' => 'mypassword'
    'context' => [
        'ssl' => [
            'verify_peer' => false,
            'verify_peer_name' => false,
        ]
    ],
];

$client = new ManageSieve($params);
```

Create a instance like above

https://github.com/horde/ManageSieve/blob/66a7ea4fbcb4a56e576d5a9055851c1bc8c57fe2/lib/Horde/ManageSieve.php#L181

Context is assigned to params the first time. user and password are > 0 so _handleConnectAndLogin is called. The method is passing $this->params['context'] to connect. 

https://github.com/horde/ManageSieve/blob/66a7ea4fbcb4a56e576d5a9055851c1bc8c57fe2/lib/Horde/ManageSieve.php#L275-L280

Then $this->_params['context'] is merged with $context (which is the same because we just passed $this->_params['context'] as $context to connect). 

![image](https://user-images.githubusercontent.com/3902676/106624324-d390e700-6575-11eb-9825-bde9c3c4337a.png)

stream_context_create will ignore the above definition and go ahead with the defaults. 

```
$context = array(
	'ssl' => array(
		'verify_peer' => false,
		'verify_peer_name' => false,
	),
);

var_dump(array_merge_recursive($context, $context));
var_dump(array_replace_recursive($context, $context));

```


