### PR TITLE
feat(auth): add XOAUTH2 authentication support to ManageSieve client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -12,6 +12,7 @@
  * @author    Damian Fernandez Sosa <damlists@cnba.uba.ar>
  * @author    Anish Mistry <amistry@am-productions.biz>
  * @author    Jan Schneider <jan@horde.org>
+ * @author    Jean Charles Delépine <delepine@u-picardie.fr>
  * @license   http://www.horde.org/licenses/bsd BSD
  */
 
@@ -83,6 +84,11 @@ class Client
     const AUTH_EXTERNAL = 'EXTERNAL';
 
     /**
+    * XOAUTH2 authentication.
+    */
+    const AUTH_XOAUTH2 = 'XOAUTH2';
+
+    /**
      * The authentication methods this class supports.
      *
      * Can be overwritten if having problems with certain methods.
@@ -95,6 +101,7 @@ class Client
         self::AUTH_EXTERNAL,
         self::AUTH_PLAIN,
         self::AUTH_LOGIN,
+        self::AUTH_XOAUTH2,
     );
 
     /**
@@ -161,6 +168,9 @@ class Client
      *   - port: Port of server (DEFAULT: 4190).
      *   - user: Login username (optional).
      *   - password: Login password (optional).
+     *   - xoauth2_token: (mixed) If set, will authenticate via the XOAUTH2
+     *                    mechanism (if available) with this token. Either a
+     *                    string or a Horde\ManageSieve\Password object.
      *   - authmethod: Type of login to perform (see $supportedAuthMethods)
      *                 (DEFAULT: AUTH_AUTOMATIC).
      *   - euser: Effective user. If authenticating as an administrator, login
@@ -196,6 +206,7 @@ class Client
                 'secure'     => true,
                 'timeout'    => 5,
                 'user'       => '',
+                'xoauth2_token' => null,
             ),
             $params
         );
@@ -216,9 +227,32 @@ class Client
         }
 
         if (strlen($this->_params['user']) &&
-            strlen($this->_params['password'])) {
+            (strlen((string)$this->_params['password']) || $this->getParam('xoauth2_token'))) {
             $this->_handleConnectAndLogin();
         }
+    }
+
+    /**
+     * Get a connection parameter.
+     *
+     * @param string $key  The parameter key.
+     *
+     * @return mixed  The parameter value, or null if it doesn't exist.
+     */
+    public function getParam($key)
+    {
+        switch ($key) {
+        case 'xoauth2_token':
+            if (isset($this->_params[$key]) &&
+                ($this->_params[$key] instanceof Password)) {
+                return $this->_params[$key]->getPassword();
+            }
+            break;
+        }
+
+        return isset($this->_params[$key])
+            ? $this->_params[$key]
+            : null;
     }
 
     /**
@@ -612,6 +646,9 @@ class Client
         case self::AUTH_EXTERNAL:
             $this->_authEXTERNAL($uid, $pwd, $euser);
             break;
+        case self::AUTH_XOAUTH2:
+            $this->_authXOAUTH2($uid, $this->getParam('xoauth2_token'), $euser);
+            break;
         default :
             throw new Exception(
                 $method . ' is not a supported authentication method'
@@ -735,6 +772,22 @@ class Client
             base64_encode(strlen($euser) ? $euser : $user)
         );
         return $this->_sendCmd($cmd);
+    }
+
+    /**
+     * Authenticates the user using the XOAUTH2 method.
+     *
+     * @param string $user  The userid to authenticate as.
+     * @param string $token The XOAUTH2 token (already formatted).
+     * @param string $euser The effective uid to authenticate as. Not used.
+     *
+     * @throws \Horde\ManageSieve\Exception
+     */
+    protected function _authXOAUTH2($user, $token, $euser)
+    {
+        return $this->_sendCmd(
+            sprintf('AUTHENTICATE "XOAUTH2" "%s"', $token)
+        );
     }
 
     /**

--- a/src/Password.php
+++ b/src/Password.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright 2025 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @category  Horde
+ * @copyright 2025 Horde LLC
+ * @license   http://www.horde.org/licenses/bsd BSD
+ * @package   ManageSieve
+ */
+
+namespace Horde\ManageSieve;
+
+/**
+ * Interface representing a ManageSieve password object.
+ *
+ * @author    Jean Charles Delepine <delepine@u-picardie.fr>
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/bsd BSD
+ * @package   ManageSieve
+ * @since     2.0.0
+ */
+interface Password
+{
+    /**
+     * Return the password to use for the server connection.
+     *
+     * @return string  The password.
+     */
+    public function getPassword();
+}

--- a/src/Password/Xoauth2.php
+++ b/src/Password/Xoauth2.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright 2025 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @category  Horde
+ * @copyright 2025 Horde LLC
+ * @license   http://www.horde.org/licenses/bsd BSD
+ * @package   ManageSieve
+ */
+
+namespace Horde\ManageSieve\Password;
+
+/**
+ * Generates an OAuth 2.0 authentication token as used in the XOAUTH2
+ * authentication mechanism.
+ *
+ * See: https://developers.google.com/gmail/xoauth2_protocol
+ *
+ * @author    Jean Charles Delepine <delepine@u-picardie.fr>
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/bsd BSD
+ * @package   ManageSieve
+ * @since     2.0.0
+ */
+class Xoauth2 implements \Horde\ManageSieve\Password
+{
+    /**
+     * Access token.
+     *
+     * @var string
+     */
+    public $access_token;
+
+    /**
+     * Username.
+     *
+     * @var string
+     */
+    public $username;
+
+    /**
+     * Constructor.
+     *
+     * @param string $username      The username.
+     * @param string $access_token  The access token.
+     */
+    public function __construct($username, $access_token)
+    {
+        $this->username = $username;
+        $this->access_token = $access_token;
+    }
+
+    /**
+     * Return the password to use for the server connection.
+     *
+     * @return string  The password.
+     */
+    public function getPassword()
+    {
+        // base64("user=" {User} "^Aauth=Bearer " {Access Token} "^A^A")
+        // ^A represents a Control+A (\001)
+        return base64_encode(
+            'user=' . $this->username . "\1" .
+            'auth=Bearer ' . $this->access_token . "\1\1"
+        );
+    }
+}

--- a/test/Unit/Xoauth2Test.php
+++ b/test/Unit/Xoauth2Test.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/bsd BSD
+ * @package   ManageSieve
+ */
+
+namespace Horde\ManageSieve\Test\Unit;
+
+use Horde\ManageSieve\Password;
+use Horde\ManageSieve\Password\Xoauth2;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Xoauth2::class)]
+class Xoauth2Test extends TestCase
+{
+    public function testTokenGeneration(): void
+    {
+        // Example from https://developers.google.com/gmail/xoauth2_protocol
+        $xoauth2 = new Xoauth2(
+            'someuser@example.com',
+            'vF9dft4qmTc2Nvb3RlckBhdHRhdmlzdGEuY29tCg==',
+        );
+        $this->assertEquals(
+            'dXNlcj1zb21ldXNlckBleGFtcGxlLmNvbQFhdXRoPUJlYXJlciB2RjlkZnQ0cW1UYzJOdmIzUmxja0JoZEhSaGRtbHpkR0V1WTI5dENnPT0BAQ==',
+            $xoauth2->getPassword(),
+        );
+    }
+
+    public function testImplementsPasswordInterface(): void
+    {
+        $xoauth2 = new Xoauth2('user@example.com', 'token');
+        $this->assertInstanceOf(Password::class, $xoauth2);
+    }
+
+    public function testUsernameIsAccessible(): void
+    {
+        $xoauth2 = new Xoauth2('user@example.com', 'token');
+        $this->assertSame('user@example.com', $xoauth2->username);
+    }
+
+    public function testAccessTokenIsAccessible(): void
+    {
+        $xoauth2 = new Xoauth2('user@example.com', 'mytoken');
+        $this->assertSame('mytoken', $xoauth2->access_token);
+    }
+}


### PR DESCRIPTION
  #### Summary                                                                    
                                                                                  
  This PR adds XOAUTH2 authentication support to the ManageSieve client,          
  following the same pattern already established in  horde/Imap_Client            
  ( Horde_Imap_Client_Password_Xoauth2 ) and  horde/Smtp                          
  ( Horde_Smtp_Password_Xoauth2 ).                                                
                                                                                  
  #### Context                                                                    
                                                                                  
  Modern mail infrastructure requires XOAUTH2 for all protocols, including             
  ManageSieve (port 4190). Deployments using OAuth2/OIDC single sign-on           
  (e.g. Apereo CAS, Keycloak) cannot use password-based ManageSieve               
  authentication at all: no password is available, only an OAuth2 access          
  token. This PR is a prerequisite for a forthcoming OIDC authentication          
  infrastructure for Horde; without it, Sieve filter management in Ingo is broken         
  for XOAUTH2-only deployments.                                                   
                                                                                  
  This PR is self-contained and independent: it introduces no new                 
  dependencies, does not change existing behaviour for password-based             
  authentication, and can be reviewed and merged on its own merits.               
                                                                                  
  #### Changes                                                                    
                                                                                  
   src/Password.php  — new interface  Horde\ManageSieve\Password ,                
  parallel to  Horde_Imap_Client_Base_Password  and  Horde_Smtp_Password .        
                                                                                  
   src/Password/Xoauth2.php  — new class implementing the interface,              
  encoding credentials as per the XOAUTH2 spec                                    
  ( base64("user={user}\x01auth=Bearer {token}\x01\x01") ). Identical             
  logic to  Horde_Imap_Client_Password_Xoauth2  and                               
   Horde_Smtp_Password_Xoauth2 .                                                  
                                                                                  
   src/Client.php  — minimal additions:                                           
                                                                                  
  •  AUTH_XOAUTH2 = 'XOAUTH2'  constant                                           
  •  'XOAUTH2'  added to  $supportedAuthMethods                                   
  •  'xoauth2_token'  parameter in constructor defaults                           
  •  getParam('xoauth2_token')  — resolves a  Password  object to its             
  encoded string, or returns the raw value                                        
  • Constructor triggers connect+login when  xoauth2_token  is set and            
  no password is provided                                                         
  •  _cmdAuthenticate()  dispatches to  _authXOAUTH2()  when method is            
   AUTH_XOAUTH2                                                                   
  •  _authXOAUTH2()  — sends  AUTHENTICATE "XOAUTH2" "{token}"                    
                                                                                  
  All existing code paths for password-based authentication are                   
  unchanged.                                                                      
                                                                                  
  #### Architecture note                                                          
                                                                                  
   horde/Smtp  has been refactored to use dedicated  Authenticator  and           
   Credentials  classes, while  Horde_Imap_Client  and  horde/ManageSieve         
  both use the classic inline authentication pattern in  Client.php . This        
  PR intentionally stays within the existing  Client.php  architecture.           
  Refactoring  Client.php  to match the Smtp pattern would affect all             
  authentication methods (PLAIN, LOGIN, DIGEST-MD5, CRAM-MD5, EXTERNAL)           
  and is out of scope here — that work is better addressed in a dedicated         
  PR.                                                                             
                                                                                  
  #### Compatibility note                                                         
                                                                                  
  If the server does not advertise  XOAUTH2  in its SASL capabilities,            
   _getBestAuthMethod()  will throw the existing                                  
   Horde\ManageSieve\Exception  — same behaviour as for any unsupported           
  method.                                                                         
                                                                                  
  #### Tests                                                                      
                                                                                  
   test/Unit/Xoauth2Test.php  — unit test for the                                 
   Xoauth2  password class, modelled after the equivalent tests in                
   horde/Imap_Client  and  horde/Smtp .                                           
                    